### PR TITLE
Make possible to grab/ use rust version 1.88 straight from cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 edition = "2024"
 authors = ["Juan Milkah <juanmilkah@gmail.com>"]
 license = "MIT"
+rust-version = "1.88"
 
 [workspace]
 members = ["server", "cli", "volatix-bench"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.88.0"
+components = ["rustfmt", "rust-src", "clippy"]


### PR DESCRIPTION
Make it easier for using cargo to just grab the rust specific version with this, instead of user needing to reach out to rustup